### PR TITLE
Fix project name copy paste error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 SLSC EDS (Electronic Datasheet) Plugin Custom Device allows any generic SLSC Capabilities File to be used within VeriStand.
 
-## LabVIEW Version ##
+## LabVIEW Version
 
 LabVIEW 2017
 
 
-## Developer Documentation ##
+## Developer Documentation
 
-### Design Decisions ###
+### Design Decisions
 - always use NVMEMcap.bin file and custom parser to extract all information from module. This reduces effort for maintaining the option of importing automatically from a connected module as well as an offline configuration.
 - Not showing string properties since it is unknown how they would be used in VeriStand.
 
@@ -24,7 +24,7 @@ LabVIEW 2017
 
 ## License
 
-The NI VeriStand Custom Device Testing Tools are licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.
+The SLSC EDS (Electronic Datasheet) Plugin Custom Device is licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.
 
 **This project distribution includes the following licensed software. Reuse of this software requires compliance with the associated license:**
  - JKI JSON Serialization & Deserialization Library for LabVIEW: https://github.com/JKISoftware/JKI-JSON-Serialization/blob/master/LICENSE.md


### PR DESCRIPTION
It looks like the testing tools name stuck around at the bottom of the README.

Also removed the trailing header `#`s, since they aren't needed.