### PR TITLE
Fix failing system test by referencing the SLSC chassis by IP Address

### DIFF
--- a/Source/Tests/System/Assets/config.ini
+++ b/Source/Tests/System/Assets/config.ini
@@ -2,6 +2,6 @@
 "Targets/Controller/Hardware/SLSC/SLSC Chassis/Chassis ID" = "10.2.207.133"
 
 [Properties]
-"SLSC IP Address" = "VS-Eco-SLSC-12001"
+"SLSC IP Address" = "10.2.207.133"
 "SLSC Slot" = "1"
 "Loopback Resource Name" = "rio://VS-Eco-Slave-8880/RIO0"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-eds-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix failing tests in the ATS for SLSC EDS (specifically SLSC EDS System Tests:test Read Properties)
Reference SLSC target in ATS with IP Address instead of host name in config file

### Why should this Pull Request be merged?

After changing test hosts in our automated test system, the test runner is not on the same subnet or domain as the SLSC Chassis. The SLSC API fails to resolve the IP address, and therefore fails a system test. We already do this for the System Definition.

### What testing has been done?

Made the change on the ATS manually and executed tests.
