### PR TITLE
Bump version to 24.0.0, drop 2020 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2020'
-          bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
         - version: '2023'
@@ -35,7 +33,7 @@ stages:
           target: 'All'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '23.8.0'
+      releaseVersion: '24.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\slsc_eds_custom_device'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-eds-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version to 24.0.0 and drop the automated build for VeriStand 2020.

I'm leaving the source in LabVIEW 2020 for now, so VeriStand 2020 builds are still possible locally.

### Why should this Pull Request be merged?

Necessary for a future release.

### What testing has been done?

N/A